### PR TITLE
[xdg-dbus-proxy] Fix GVariant reference leaks

### DIFF
--- a/rpm/0001-Fix-GVariant-reference-leaks.patch
+++ b/rpm/0001-Fix-GVariant-reference-leaks.patch
@@ -1,0 +1,81 @@
+From 9216c30ae1ecb3951f97746c69445243341dd979 Mon Sep 17 00:00:00 2001
+From: Simo Piiroinen <simo.piiroinen@jolla.com>
+Date: Thu, 11 Mar 2021 07:18:40 +0200
+Subject: Fix GVariant reference leaks
+
+There is memory leakage that is proportional to amount of incoming
+dbus traffic. Analyzing valgrind logs points towards GVariant
+reference leaks from functions like validate_arg0_name().
+
+Documentation for g_variant_get_child_value() states: "The returned
+value is never floating. You should free it with g_variant_unref()
+when you're done with it." Many functions omit such cleanup actions.
+
+Use g_autoptr(GVariant) type for variables that are used for storing
+g_variant_get_child_value() return value - like how it is already done
+in get_arg0_string().
+
+Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+---
+ flatpak-proxy.c | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/flatpak-proxy.c b/flatpak-proxy.c
+index 1294f63..8bf9a4f 100644
+--- a/flatpak-proxy.c
++++ b/flatpak-proxy.c
+@@ -1795,7 +1795,8 @@ static gboolean
+ validate_arg0_match (FlatpakProxyClient *client, Buffer *buffer)
+ {
+   GDBusMessage *message = g_dbus_message_new_from_blob (buffer->data, buffer->size, 0, NULL);
+-  GVariant *body, *arg0;
++  GVariant *body;
++  g_autoptr(GVariant) arg0 = NULL;
+   const char *match;
+   gboolean res = TRUE;
+ 
+@@ -1817,7 +1818,8 @@ static gboolean
+ validate_arg0_name (FlatpakProxyClient *client, Buffer *buffer, FlatpakPolicy required_policy, FlatpakPolicy *has_policy)
+ {
+   GDBusMessage *message = g_dbus_message_new_from_blob (buffer->data, buffer->size, 0, NULL);
+-  GVariant *body, *arg0;
++  GVariant *body;
++  g_autoptr(GVariant) arg0 = NULL;
+   const char *name;
+   FlatpakPolicy name_policy;
+   gboolean res = FALSE;
+@@ -1850,7 +1852,8 @@ static Buffer *
+ filter_names_list (FlatpakProxyClient *client, Buffer *buffer)
+ {
+   GDBusMessage *message = g_dbus_message_new_from_blob (buffer->data, buffer->size, 0, NULL);
+-  GVariant *body, *arg0, *new_names;
++  GVariant *body, *new_names;
++  g_autoptr(GVariant) arg0 = NULL;
+   const gchar **names;
+   int i;
+   GVariantBuilder builder;
+@@ -1896,7 +1899,10 @@ static gboolean
+ should_filter_name_owner_changed (FlatpakProxyClient *client, Buffer *buffer)
+ {
+   GDBusMessage *message = g_dbus_message_new_from_blob (buffer->data, buffer->size, 0, NULL);
+-  GVariant *body, *arg0, *arg1, *arg2;
++  GVariant *body;
++  g_autoptr(GVariant) arg0 = NULL;
++  g_autoptr(GVariant) arg1 = NULL;
++  g_autoptr(GVariant) arg2 = NULL;
+   const gchar *name, *new;
+   gboolean filter = TRUE;
+ 
+@@ -2092,7 +2098,8 @@ static void
+ queue_wildcard_initial_name_ops (FlatpakProxyClient *client, Header *header, Buffer *buffer)
+ {
+   GDBusMessage *decoded_message = g_dbus_message_new_from_blob (buffer->data, buffer->size, 0, NULL);
+-  GVariant *body, *arg0;
++  GVariant *body;
++  g_autoptr(GVariant) arg0 = NULL;
+ 
+   if (decoded_message != NULL &&
+       header->type == G_DBUS_MESSAGE_TYPE_METHOD_RETURN &&
+-- 
+2.17.1
+

--- a/rpm/xdg-dbus-proxy.spec
+++ b/rpm/xdg-dbus-proxy.spec
@@ -5,6 +5,7 @@ Summary:        Filtering proxy for D-Bus connections
 License:        LGPLv2+
 URL:            https://github.com/flatpak/xdg-dbus-proxy
 Source0:        %{name}-%{version}.tar.xz
+Patch1:         0001-Fix-GVariant-reference-leaks.patch
 
 BuildRequires:  autoconf
 BuildRequires:  autoconf-archive
@@ -20,7 +21,7 @@ originally part of the flatpak project, but it has been broken out
 as a standalone module to facilitate using it in other contexts.
 
 %prep
-%setup -q -n %{name}-%{version}/upstream
+%autosetup -p1 -n %{name}-%{version}/upstream
 
 %build
 %autogen --disable-static --enable-man=no


### PR DESCRIPTION
There are functions that return without releasing GVariant references
obtained via g_variant_get_child_value().

Use g_autoptr(GVariant) type so that such references are automatically
released upon return from function.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>